### PR TITLE
fix livesearch: find charset ("<>), bug - later search without html e…

### DIFF
--- a/vendor/assets/javascripts/bootstrap-select.js
+++ b/vendor/assets/javascripts/bootstrap-select.js
@@ -1284,7 +1284,12 @@
         if (that.$searchbox.val()) {
           var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').children('a');
           if (that.options.liveSearchNormalize) {
-            $searchBase = $searchBase.not(':a' + that._searchStyle() + '("' + normalizeToBase(that.$searchbox.val()) + '")');
+              $.each($searchBase, function () {
+                  if (normalizeToBase(htmlEscape($(this).text())).indexOf(normalizeToBase(htmlEscape(that.$searchbox.val()))) > -1)
+                  {
+                      $searchBase= $searchBase.not($(this))
+                  }
+              });
           } else {
             $searchBase = $searchBase.not(':' + that._searchStyle() + '("' + that.$searchbox.val() + '")');
           }


### PR DESCRIPTION
When liveSearchNormalize is true, liveserach find text without ntml Escape.